### PR TITLE
Improve app loading + new frame rate input

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -42,8 +42,8 @@
                 <h2><img src="icons/play.png"/><span>Playback</span></h2>
                 <ul>
                     <li>
-                      <label id="label-fps-change" for="input-fps-change">Select frame rate</label>
-                      <input id="input-fps-change" type="number" value="15">
+                      <label id="label-fr-change" for="input-fr-change">Select frame rate</label>
+                      <input id="input-fr-change" type="number" value="15">
                     </li>
                     <li>
                       <input id="loopCheckbox" type="checkbox" name="options" value="Download">

--- a/app/index.html
+++ b/app/index.html
@@ -44,8 +44,14 @@
             <li>
                 <h2><img src="icons/play.png"/><span>Playback</span></h2>
                 <ul>
-                    <li><a id="changeFrameRate" href="#"> Select frame rate</a></li>
-                    <li><input id="loopCheckbox" type="checkbox" name="options" value="Download"/><span> Loop frames on playback</span></li>
+                    <li>
+                      <label id="label-fps-change" for="input-fps-change">Select frame rate</label>
+                      <input id="input-fps-change" type="number" value="15">
+                    </li>
+                    <li>
+                      <input id="loopCheckbox" type="checkbox" name="options" value="Download">
+                      <label for="loopCheckbox"><span>Loop frames on playback</span></label>
+                    </li>
 
                 </ul>
             </li>

--- a/app/index.html
+++ b/app/index.html
@@ -4,9 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2">
     <title>Boats Animator</title>
-    <script src="variables.js"></script>
-    <script src="main.js" type="text/javascript"></script>
-    <script src="nw.js" type="text/javascript"></script>
     <link rel="stylesheet" href="main.css">
     <link rel="stylesheet" href="nw.css">
 </head>
@@ -138,8 +135,8 @@
         </div>
     </div>
 
-
-
-
+    <script src="variables.js"></script>
+    <script src="main.js"></script>
+    <script src="nw.js"></script>
 </body>
 </html>

--- a/app/main.css
+++ b/app/main.css
@@ -503,5 +503,5 @@ input[type="range"]:hover{
 }
 #options-onion-skin.visible { max-height: 5.9em; }
 
-/* FPS input */
-#input-fps-change { margin-top: 0.3em; }
+/* Frame rate input */
+#input-fr-change { margin-top: 0.3em; }

--- a/app/main.css
+++ b/app/main.css
@@ -502,3 +502,6 @@ input[type="range"]:hover{
     transition: max-height 0.4s ease;
 }
 #options-onion-skin.visible { max-height: 5.9em; }
+
+/* FPS input */
+#input-fps-change { margin-top: 0.3em; }

--- a/app/main.js
+++ b/app/main.js
@@ -120,9 +120,8 @@ function startup() {
     }, false);
 
     //listen if onion skin toggle pressed
-    onionSkinToggle.addEventListener('click', function(ev){
+    onionSkinToggle.addEventListener('click', function() {
         toggleOnionSkin();
-        ev.preventDefault();
     }, false);
 
     //listen if playback button is pressed
@@ -294,7 +293,7 @@ function startup() {
     }
 
 /**
- * Toggle onion skin on or off.
+ * Toggle onion skinning on or off.
  */
 function toggleOnionSkin() {
     "use strict";

--- a/app/main.js
+++ b/app/main.js
@@ -1,75 +1,55 @@
-
-  // The width and height of the captured photo. We will set the
-  // width to the value defined here, but the height will be
-  // calculated based on the aspect ratio of the input stream.
-
+// The width and height of the captured photo. We will set the
+// width to the value defined here, but the height will be
+// calculated based on the aspect ratio of the input stream.
 var width = 480,    // We will scale the photo width to this
     height = 0,     // This will be computed based on the input stream
 
-  // |streaming| indicates whether or not we're currently streaming
-  // video from the camera. Obviously, we start at false.
-
+    // |streaming| indicates whether or not we're currently streaming
+    // video from the camera. Obviously, we start at false.
     streaming = false,
 
-  // The various HTML elements we need to configure or control. These
-  // will be set by the startup() function.
-    preview = null,
-    video = null,
-    canvas = null,
-    photo = null,
-    //CAPTURE
-    captureFrame = null,
-    capturedFramesList = [],
-    capturedFramesRaw = [],
-    onionSkinFrame = null,
-    deleteLastFrame = null,
-    noOfFrames = null,
-    lastFrame = null,
-    //PLAYBACK
-    playbackButton = null,
-    stopPlaybackButton = null,
-    pausePlaybackButton = null,
-    changeFrameRateButton = null,
-    backCapturedFrameButton = null,
-    forwardCapturedFrameButton = null,
-    scrollFrames = null,
-    frameRate = 0,
-    isPlaying = false,
-    loopCheck = null,
-    //CAPTURED FRAMES TIMELINE
+    // The various HTML elements we need to configure or control.
+    preview = document.getElementById('preview'),
+    video   = document.getElementById('video'),
+    canvas  = document.getElementById('canvas'),
+    photo   = document.getElementById('photo'),
 
-    //ONION SKIN
+    // Capture
+    capturedFramesRaw  = [],
+    capturedFramesList = [],
+    captureFrame       = document.getElementById('captureFrame'),
+    deleteLastFrame    = document.getElementById('deleteLastFrame'),
+    noOfFrames         = null,
+    lastFrame          = null,
+
+    // Playback
+    scrollFrames               = null,
+    frameRate                  = 0,
+    isPlaying                  = false,
+    loopCheck                  = document.getElementById("loopCheckbox"),
+    playbackButton             = document.getElementById("playbackFrames"),
+    stopPlaybackButton         = document.getElementById("stopPlayback"),
+    pausePlaybackButton        = document.getElementById("pausePlayback"),
+    inputChangeFPS             = document.querySelector(document.BoatsAnimator.getVariable("inputFPSChange")),
+    backCapturedFrameButton    = document.getElementById("backCapturedFrame"),
+    forwardCapturedFrameButton = document.getElementById("forwardCapturedFrame"),
+
+    // Captured Frames Timeline
+    // TODO
+
+    // Onion skin
+    onionSkinFrame     = null,
     isOnionSkinEnabled = false,
-    onionSkinToggle = null,
-    onionSkinPanel = null,
-    onionSkinWindow = null,
-    onionSkinFrame = null;
+    onionSkinPanel     = document.querySelector(document.BoatsAnimator.getVariable("onionSkinOptions")),
+    onionSkinToggle    = document.querySelector(document.BoatsAnimator.getVariable("onionSkinToggle")),
+    onionSkinWindow    = document.querySelector(document.BoatsAnimator.getVariable("onionSkinFrame"));
 
 function startup() {
-    preview = document.getElementById('preview');
-    video = document.getElementById('video');
-    canvas = document.getElementById('canvas');
-    photo = document.getElementById('photo');
-    //CAPTURE
-    captureFrame = document.getElementById('captureFrame');
-    deleteLastFrame = document.getElementById('deleteLastFrame');
-    noOfFrames = capturedFramesRaw.length;
-    lastFrame = capturedFramesRaw[noOfFrames - 1];
-    //ONION SKIN
-    onionSkinToggle = document.querySelector(document.BoatsAnimator.getVariable("onionSkinToggle"));
-    onionSkinPanel = document.querySelector(document.BoatsAnimator.getVariable("onionSkinOptions"));
-    onionSkinWindow = document.querySelector(document.BoatsAnimator.getVariable("onionSkinFrame"));
+    noOfFrames     = capturedFramesRaw.length;
+    lastFrame      = capturedFramesRaw[noOfFrames - 1];
     onionSkinFrame = capturedFramesList[capturedFramesList.length];
-    //PLAYBACK
-    playbackButton = document.getElementById("playbackFrames");
-    stopPlaybackButton = document.getElementById("stopPlayback");
-    pausePlaybackButton = document.getElementById("pausePlayback");
-    changeFrameRateButton = document.getElementById("changeFrameRate");
-    backCapturedFrameButton = document.getElementById("backCapturedFrame");
-    forwardCapturedFrameButton = document.getElementById("forwardCapturedFrame");
-    frameRate = 15;
-    isPlaying = false;
-    loopCheck = document.getElementById("loopCheckbox");
+    frameRate      = 15;
+    isPlaying      = false;
 
     updateframeslist();
 

--- a/app/main.js
+++ b/app/main.js
@@ -30,7 +30,7 @@ var width = 480,    // We will scale the photo width to this
     playbackButton             = document.getElementById("playbackFrames"),
     stopPlaybackButton         = document.getElementById("stopPlayback"),
     pausePlaybackButton        = document.getElementById("pausePlayback"),
-    inputChangeFPS             = document.querySelector(document.BoatsAnimator.getVariable("inputFPSChange")),
+    inputChangeFR              = document.querySelector(document.BoatsAnimator.getVariable("inputFRChange")),
     backCapturedFrameButton    = document.getElementById("backCapturedFrame"),
     forwardCapturedFrameButton = document.getElementById("forwardCapturedFrame"),
 
@@ -52,6 +52,9 @@ function startup() {
     isPlaying      = false;
 
     updateframeslist();
+
+    // Set default frame rate
+    inputChangeFR.value = frameRate;
 
 
     navigator.getMedia = (navigator.getUserMedia ||
@@ -168,12 +171,12 @@ function startup() {
         ev.preventDefault();
     }, false);
 
-    //listen if change frame rate button is pressed
-    changeFrameRateButton.addEventListener('click', function(ev){
-        frameRate = prompt("Please enter a frame rate", frameRate);
-        document.getElementById("currentFrameRate").innerHTML = "Playback is currently at " + frameRate + " fps";
+    // Listen for frame rate changes
+    inputChangeFR.addEventListener('change', function() {
+        "use strict";
+        frameRate = parseInt(this.value, 10);
+        document.getElementById("currentFrameRate").innerHTML = "Playback is currently at " + this.value + " fps";
         stopitwhenlooping();
-        ev.preventDefault();
     }, false);
 
     //listen if left arrow button is pressed
@@ -265,7 +268,7 @@ function startup() {
             document.getElementById("noOfFrames").innerHTML = noOfFrames + " frames captured";
         }
         //display current frame rate in status bar
-        document.getElementById("currentFrameRate").innerHTML = "Playback is currently at " + frameRate + " fps";
+        document.getElementById("currentFrameRate").innerHTML = "Playback is currently at " + frameRate.toString() + " fps";
 
 
         console.log("Scrollframes: " + scrollFrames);
@@ -350,7 +353,7 @@ function toggleOnionSkin() {
         yoplayit;
 
 function playbackframes() {
-        yoplayit = setInterval(playit, (1000/frameRate));
+        yoplayit = setInterval(playit, (1000 / frameRate));
         console.info("Playback started");
 }
 function playit() {

--- a/app/variables.js
+++ b/app/variables.js
@@ -13,7 +13,8 @@ document.BoatsAnimator = {
     var variables = {
       onionSkinToggle: "#btn-onion-skin-toggle",
       onionSkinOptions: "#options-onion-skin",
-      onionSkinFrame: "#onion-skinning-frame"
+      onionSkinFrame: "#onion-skinning-frame",
+      inputFRChange: "#input-fr-change"
     };
     return variables[elementName];
   }


### PR DESCRIPTION
By moving the JS loading to right before the closing `</body>` tag (as is the universally recommended method), all selector loading can be initialized right then instead of inside `startup()`. :smile: 

Also reworked the frame rate input to be an `input type="number"` field instead of a `confirm` dialog, which is a much nicer UX. :)

If you have any questions, comments, or concerns on any of this, please, do not hesitate to ask! :smiley: