### PR TITLE
Internalize second video and canvas

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -82,11 +82,8 @@
                 <img id="onion-skinning-frame">
             </div>
 
-            <!--The actual video stream -->
+            <!-- Video preview stream -->
             <video id="preview" autoplay>Video stream not available.</video>
-
-            <!--HIDDEN CANVAS FOR CONVERSION TO PNG-->
-            <canvas id="canvas"></canvas>
         </div>
 
         <!--Playback Window-->

--- a/app/animator.html
+++ b/app/animator.html
@@ -85,8 +85,6 @@
             <!--The actual video stream -->
             <video id="preview" autoplay>Video stream not available.</video>
 
-            <!--2ND HIDDEN VIDEO STREAM TO ALLOW FOR VARIED RESOLUTIONS-->
-            <video id="video" autoplay>Video stream not available.</video>
             <!--HIDDEN CANVAS FOR CONVERSION TO PNG-->
             <canvas id="canvas"></canvas>
         </div>
@@ -133,7 +131,7 @@
                 </table>
             </div>
         </div>
-      
+
         <div id="other-options-container">
                 <div id="framerate-container"><input id="input-fr-change" type="number" value="15" min="1" title="Framerate"><label for="input-fr-change"> FPS</label></div>
         </div>

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -103,7 +103,7 @@ a {
 
 /* ========== VIDEO PREVIEW ============== */
 
-#video, #canvas { display: none; }
+#canvas { display: none; }
 
 #captureWindow, #playbackWindow {
   height: calc(100vh - 56px - 130px - 60px);

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -103,8 +103,6 @@ a {
 
 /* ========== VIDEO PREVIEW ============== */
 
-#canvas { display: none; }
-
 #captureWindow, #playbackWindow {
   height: calc(100vh - 56px - 130px - 60px);
 /*  height: 30em;*/

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -15,7 +15,7 @@ var width  = 640,
     // The various HTML elements we need to configure or control.
     preview     = document.querySelector("#preview"),
     video       = document.createElement("video"),
-    canvas      = document.querySelector("#canvas"),
+    canvas      = document.createElement("canvas"),
     ratio       = null,
     aspectRatio = null,
 
@@ -126,14 +126,14 @@ function startup() {
     statusBarFrameRate.innerHTML = frameRate;
     inputChangeFR.value = frameRate;
 
-    //Set default view
+    // Set default view
     switchMode("capture");
 
     // Get the appropriate WebRTC implementation
     navigator.getMedia = navigator.getUserMedia || navigator.webkitGetUserMedia;
 
     navigator.getMedia({ video: true },
-        function (stream) {
+        function(stream) {
             var videoBlob = window.URL.createObjectURL(stream);
             // Play preview video
             preview.src = videoBlob;
@@ -142,7 +142,7 @@ function startup() {
             video.src = videoBlob;
             video.play();
         },
-        function (err) {
+        function(err) {
             console.error("Could not find a camera to use!");
             notifyError("Could not find a camera to use!");
         }
@@ -167,7 +167,7 @@ function startup() {
 
             notifySuccess("Camera successfully connected.");
         }
-    }, false);
+    });
 
 
 /*==========================================================

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -14,7 +14,7 @@ var width  = 640,
 
     // The various HTML elements we need to configure or control.
     preview     = document.querySelector("#preview"),
-    video       = document.querySelector("#video"),
+    video       = document.createElement("video"),
     canvas      = document.querySelector("#canvas"),
     ratio       = null,
     aspectRatio = null,
@@ -24,7 +24,7 @@ var width  = 640,
     win = gui.Window.get(),
 
     // Mode switching
-    btnLiveView  = document.querySelector("#btn-live-view"),
+    btnLiveView    = document.querySelector("#btn-live-view"),
     captureWindow  = document.querySelector("#captureWindow"),
     playbackWindow = document.querySelector("#playbackWindow"),
     winMode        = "capture",
@@ -84,7 +84,7 @@ function openAnimator() {
     win.focus();
     window.location.href = "animator.html";
     win.resizeTo(1050, 715);
-    win.setPosition('center');
+    win.setPosition("center");
     win.maximize();
 }
 
@@ -140,6 +140,7 @@ function startup() {
 
             //  Play hidden video of correct resolution
             video.src = videoBlob;
+            video.play();
         },
         function (err) {
             console.error("Could not find a camera to use!");
@@ -147,14 +148,12 @@ function startup() {
         }
     );
 
-    video.addEventListener('canplay', function () {
+    video.addEventListener("canplay", function() {
         if (!streaming) {
             height = video.videoHeight / (video.videoWidth / width);
 
-            video.setAttribute('width', width);
-            video.setAttribute('height', height);
-            canvas.setAttribute('width', width);
-            canvas.setAttribute('height', height);
+            canvas.setAttribute("width", video.videoWidth.toString());
+            canvas.setAttribute("height", video.videoHeight.toString());
             streaming = true;
             ratio = width / height;
             aspectRatio = ratio.toFixed(2);

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -360,15 +360,15 @@ function _toggleOnionSkin(ev) {
     // Onion skin is currently enabled, turn it off
     if (isOnionSkinEnabled) {
       isOnionSkinEnabled = false;
-      ev.target.setAttribute("title", `Enable Onion Skin`);
-      onionSkinToggle.children[0].classList.remove("active")
+      ev.target.setAttribute("title", "Enable Onion Skin");
+      onionSkinToggle.children[0].classList.remove("active");
       onionSkinWindow.classList.remove("visible");
 
       // Onion skin is currently disabled, turn it on
     } else {
       isOnionSkinEnabled = true;
-        ev.target.setAttribute("title", `Disable Onion Skin`);
-      onionSkinToggle.children[0].classList.add("active")
+      ev.target.setAttribute("title", "Disable Onion Skin");
+      onionSkinToggle.children[0].classList.add("active");
 
       // Display last captured frame
       onionSkinWindow.classList.add("visible");


### PR DESCRIPTION
Having them in the DOM and constantly rendering them creates an unnecessary performance drop. By keeping them in-memory only, we speed up the UI and improve overall performance.