### PR TITLE
Added red border around capture window

### DIFF
--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -45,7 +45,7 @@ a {
 .notification.hidden { transform: translate3d(0, -110%, 0); }
 .notification.success { background-color: #2d9e2d; }
 .notification.info { background-color: #3a3ae1; }
-.notification.error { background-color: #c90000; }
+.notification.error { background-color: #ad0000; }
 
 .notification #msg {
   margin: 0;
@@ -158,6 +158,8 @@ a {
 #captureWindow.hidden,
 #playbackWindow.hidden { display: none; }
 
+#captureWindow.active { border: 2px solid #ad0000; }
+
 #preview {
   max-width: 100%;
   padding: 0;
@@ -254,7 +256,7 @@ a {
 }
 
 #btn-loop i.active, #btn-onion-skin-toggle i.active {
-  color: #c90000;
+  color: #ad0000;
 }
 
 /* ========== FRAME REEL ============== */

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -280,11 +280,13 @@ function switchMode(newMode) {
     if (winMode === "capture") {
         playbackWindow.classList.add("hidden");
         captureWindow.classList.remove("hidden");
+        captureWindow.classList.add("active");
         btnLiveView.classList.add("selected");
 
     } else if (winMode === "playback") {
-        captureWindow.classList.add("hidden");
         playbackWindow.classList.remove("hidden");
+        captureWindow.classList.add("hidden");
+        captureWindow.classList.remove("active");
         btnLiveView.classList.remove("selected");
     }
     console.log(`Switched to: ${winMode}`);


### PR DESCRIPTION
This adds more clarity for someone so they know if they are in capture or preview mode. May need tweaking.

Note: I know the branch is called `splash-screen-css`, but I made the branch before I knew you redesigned the splash screen, so I just used the branch to add this change :P