### PR TITLE
(Even more) various fixes

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -154,7 +154,7 @@
         <table id="control-panel-table">
             <tr>
                 <td id="onion-toggle-td">
-                    <div id="btn-grid-toggle"><a href="#" onclick="alert('Coming soon!');"><i class="fa fa-th" title="Grid Overlay"></i></a></div>
+                    <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
                     <div id="btn-onion-skin-toggle"><i class="fa fa-adjust fa-flip-horizontal" title="Enable Onion Skin"></i></div>
                 </td>
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -351,6 +351,7 @@ function updateFrameReel(action, id) {
     "use strict";
     var onionSkinFrame = id - 1;
     // Display number of captured frames in status bar
+    statusBarCurFrame.innerHTML = curFrame;
     statusBarFrameNum.innerHTML = `${curFrame} ${curFrame === 1 ? "frame" : "frames"}`;
 
     // Add the newly captured frame
@@ -388,11 +389,13 @@ function updateFrameReel(action, id) {
 
         // Update onion skin frame
         onionSkinWindow.setAttribute("src", capturedFramesRaw[onionSkinFrame]);
+        playback.setAttribute("src", capturedFramesRaw[onionSkinFrame]);
 
         // All the frames were deleted, display "No frames" message
     } else {
         frameReelMsg.classList.remove("hidden");
         frameReelTable.classList.add("hidden");
+        switchMode("capture");
     }
 }
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -32,9 +32,9 @@ var width  = 640,
     // Capture
     capturedFramesRaw  = [],
     curFrame           = 0,
+    // curSelectedFrame   = null,
     btnCaptureFrame    = document.querySelector("#btn-capture-frame"),
     btnDeleteLastFrame = document.querySelector("#btn-delete-last-frame"),
-    captureAudio       = new Audio("audio/camera.wav"),
 
     // Playback
     frameRate     = 15,
@@ -49,7 +49,8 @@ var width  = 640,
     inputChangeFR = document.querySelector("#input-fr-change"),
 
     // Audio
-    audioToggle = document.querySelector("#audio-toggle"),
+    captureAudio = new Audio("audio/camera.wav"),
+    audioToggle  = document.querySelector("#audio-toggle"),
 
     // Status bar
     statusBarCurMode   = document.querySelector("#currentMode span"),
@@ -94,7 +95,7 @@ var width  = 640,
  */
 function openAnimator() {
     "use strict";
-    gui.Window.open ("animator.html", {
+    gui.Window.open("animator.html", {
         position: "center",
         width: 1050,
         height: 715,
@@ -113,7 +114,7 @@ function openAnimator() {
 function openIndex() {
     "use strict";
     win.close();
-    gui.Window.open ("index.html", {
+    gui.Window.open("index.html", {
         position: "center",
         width: 730,
         height: 450,
@@ -287,6 +288,7 @@ function startup() {
             var imageID = parseInt(e.target.id.match(/^img-(\d+)$/)[1], 10);
             playback.setAttribute("src", capturedFramesRaw[imageID - 1]);
             curPlayFrame = imageID - 1;
+            // curSelectedFrame = imageID;
             statusBarCurFrame.innerHTML = imageID;
         }
     });
@@ -325,6 +327,7 @@ function removeFrameReelSelection() {
     var selectedFrame = document.querySelector(".frame-reel-img.selected");
     if (selectedFrame) {
         selectedFrame.classList.remove("selected");
+        // curSelectedFrame = null;
         return true;
     }
     return false;

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -33,6 +33,7 @@ var width  = 640,
     capturedFramesRaw  = [],
     curFrame           = 0,
     // curSelectedFrame   = null,
+    btnGridToggle      = document.querySelector("#btn-grid-toggle"),
     btnCaptureFrame    = document.querySelector("#btn-capture-frame"),
     btnDeleteLastFrame = document.querySelector("#btn-delete-last-frame"),
 
@@ -263,6 +264,11 @@ function startup() {
         if (inputChangeFR.value > 60 || inputChangeFR.value < 1 || NaN || inputChangeFR.length > 2) {
             inputChangeFR.value = 15;
         }
+    });
+
+    // Grid overlay toggle
+    btnGridToggle.addEventListener("click", function() {
+        notifyInfo("That feature is not yet implemented.");
     });
 
     // Switch from frame preview back to live view

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -32,7 +32,7 @@ var width  = 640,
     // Capture
     capturedFramesRaw  = [],
     curFrame           = 0,
-    // curSelectedFrame   = null,
+    curSelectedFrame   = null,
     btnGridToggle      = document.querySelector("#btn-grid-toggle"),
     btnCaptureFrame    = document.querySelector("#btn-capture-frame"),
     btnDeleteLastFrame = document.querySelector("#btn-delete-last-frame"),
@@ -294,7 +294,7 @@ function startup() {
             var imageID = parseInt(e.target.id.match(/^img-(\d+)$/)[1], 10);
             playback.setAttribute("src", capturedFramesRaw[imageID - 1]);
             curPlayFrame = imageID - 1;
-            // curSelectedFrame = imageID;
+            curSelectedFrame = imageID;
             statusBarCurFrame.innerHTML = imageID;
         }
     });
@@ -333,7 +333,7 @@ function removeFrameReelSelection() {
     var selectedFrame = document.querySelector(".frame-reel-img.selected");
     if (selectedFrame) {
         selectedFrame.classList.remove("selected");
-        // curSelectedFrame = null;
+        curSelectedFrame = null;
         return true;
     }
     return false;
@@ -390,6 +390,12 @@ function updateFrameReel(action, id) {
         // Update onion skin frame
         onionSkinWindow.setAttribute("src", capturedFramesRaw[onionSkinFrame]);
         playback.setAttribute("src", capturedFramesRaw[onionSkinFrame]);
+
+        // Update frame preview selection
+        if (curSelectedFrame) {
+            removeFrameReelSelection();
+            document.querySelector(`.frame-reel-img#img-${id - 1}`).classList.add("selected");
+        }
 
         // All the frames were deleted, display "No frames" message
     } else {

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -838,29 +838,29 @@ function notifyError(msg) {
 /**
  * Confirm the action to be performed.
  *
- * @param {Function} func The function to run on "OK" being pressed.
+ * @param {Function} callback The function to run on "OK" being pressed.
  * @param {*} args Arguments of function to run.
  * @param {String} msg Message to display in confirm dialogue.
  */
-function confirmSet(func, args, msg) {
+function confirmSet(callback, args, msg) {
     "use strict";
     confirmText.innerHTML = msg;
     confirmContainer.classList.remove("hidden");
 
-    // Listen if "OK" is pressed
-    btnConfirmOK.addEventListener("click", function() {
-        if (args === undefined) {
-            func();
-        } else {
-            func(args);
-        }
+    function _ok() {
         confirmContainer.classList.add("hidden");
-    });
+        callback(args);
+        btnConfirmOK.removeEventListener("click", _ok);
+    }
 
-     // Listen if "Cancel" is pressed
-    btnConfirmCancel.addEventListener("click", function() {
+    function _cancel() {
         confirmContainer.classList.add("hidden");
-    });
+        btnConfirmCancel.removeEventListener("click", _cancel);
+    }
+
+    // Respond to button clicks
+    btnConfirmOK.addEventListener("click", _ok);
+    btnConfirmCancel.addEventListener("click", _cancel);
 }
 
 /**

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -827,11 +827,11 @@ function notifyError(msg) {
 }
 
 /**
- * Display a custom confirm message
+ * Confirm the action to be performed.
  *
- * @param {String|Number} func The function to run on "OK" being pressed.
- * @param {String|Number} args Arguments of function to run.
- * @param {String|Number} msg Message to display in confirm dialogue.
+ * @param {Function} func The function to run on "OK" being pressed.
+ * @param {*} args Arguments of function to run.
+ * @param {String} msg Message to display in confirm dialogue.
  */
 function confirmSet(func, args, msg) {
     "use strict";
@@ -863,13 +863,13 @@ function loadMenu() {
     var menuBar = new gui.Menu({ type: "menubar" });
 
     // Create sub-menus
-    var fileMenu = new gui.Menu(),
-        editMenu = new gui.Menu(),
+    var fileMenu    = new gui.Menu(),
+        editMenu    = new gui.Menu(),
         captureMenu = new gui.Menu(),
-        helpMenu = new gui.Menu(),
-        debugMenu = new gui.Menu();
+        helpMenu    = new gui.Menu(),
+        debugMenu   = new gui.Menu();
 
-    //File menu items
+    // File menu items
     fileMenu.append(new gui.MenuItem({
       label: "New project...",
       click: function() {
@@ -893,7 +893,7 @@ function loadMenu() {
         modifiers: "ctrl",
     }));
 
-    //Edit menu items
+    // Edit menu items
     editMenu.append(new gui.MenuItem({
       label: "Delete last frame",
       click: function() {
@@ -903,7 +903,7 @@ function loadMenu() {
       modifiers: "ctrl",
     }));
 
-    //Capture menu items
+    // Capture menu items
     captureMenu.append(new gui.MenuItem({
       label: "Capture frame",
       click: function() {
@@ -913,7 +913,7 @@ function loadMenu() {
       modifiers: "ctrl",
     }));
 
-    //Help menu items
+    // Help menu items
     helpMenu.append(new gui.MenuItem({
       label: "Give feedback",
       click: function() {
@@ -923,7 +923,7 @@ function loadMenu() {
       modifiers: "ctrl",
     }));
 
-    //Debug menu items
+    // Debug menu items
     debugMenu.append(new gui.MenuItem({
       label: "Load developer tools",
       click: function() {


### PR DESCRIPTION
Fixed these while working on #83. I would have waited to submit these but they are such obvious bugs that they should have already been fixed (+ one or two improvements and one important fix that was creating bugs).

* Make the Grid Overlay button use `notifyInfo()` instead `alert()`
* Update the current frame count in status bar when taking a new frame
* Set last taken frame (if possible) in playback window when deleting a
frame
* Automatically switch to capture mode if all frames are deleted
* Update frame preview selection when undoing a frame
* Fix a really bad listeners error in `confirmSet()` (`!important`)

I plan on writing a [blog post](https://triangle717.wordpress.com/) about the last one, but for a quick tl;dr here: the event listeners were getting adding to the buttons each time `confirmSet()` was called. If it was called three times, that means they received three listeners, meaning the callback would be run (you guessed it) three times. While `addEventListener` has safeguards to prevent identical, duplicate listeners, the way the function was written meant they did not apply. This patch makes sure the listeners are applied _once_ each the `confirmSet()` is called. As I said, I will detail more in an (eventual) post.

It's kinda my fault for letting this happen. In the back of my mind I knew this was happening but I didn't clearly acknowledge it. It's OK though. It is fixed now. :) 