### PR TITLE
Rework notifications markup and styling

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -11,8 +11,11 @@
 
 <body onload="startup()">
     <!--Notification Bar-->
-    <section class="notification hidden">
-        <p id="msg"></p>
+    <section id="notification-container">
+        <div class="notification hidden">
+            <div class="notify-type"></div>
+            <div class="msg"></div>
+        </div>
     </section>
 
     <!--Confirm messages-->

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -24,31 +24,50 @@ a {
   cursor: pointer;
 }
 
-/* ========== NOTIFICATION BAR ============== */
+/* ========== Notification bar ============== */
 
-.notification {
-  width: 60%;
-  min-height: 3em;
+#notification-container {
+  width: 100vw;
   position: fixed;
-  left: 18vw;
-  padding-top: 0.2em;
-  padding-bottom: 0.5em;
+  left: 20vw;
+}
+
+/* Individual notification */
+.notification {
+  width: 50%;
+  padding-top: 0.5em;
+  padding-bottom: 0.6em;
+  background-color: #2b2b2b;
   box-shadow: 0 1px 5px 1px rgba(27, 27, 27, 0.4);
   z-index: 5;
   color: #fff;
   transition: transform 0.3s ease;
 }
 
+/* Notification type label */
+.notify-type {
+  margin-top: 0.2em;
+  margin-right: 0.5em;
+  margin-left: 0.5em;
+  padding: 0.1em 0.5em;
+  display: inline-block;
+  vertical-align: middle;
+  font-size: 0.9em;
+}
+
 /* Notification states */
 .notification.hidden { transform: translate3d(0, -110%, 0); }
-.notification.success { background-color: #2d9e2d; }
-.notification.info { background-color: #3a3ae1; }
-.notification.error { background-color: #ad0000; }
+.notification.success .notify-type { background-color: #2d9e2d; }
+.notification.info .notify-type { background-color: #3a3ae1; }
+.notification.error .notify-type { background-color: #ad0000; }
 
-.notification #msg {
+/* Notification message */
+.notification .msg {
   margin: 0;
-  font-size: 1.6em;
+  font-size: 1.2em;
   text-align: center;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 /* ========== CONFIRM BOXES ========== */

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -78,9 +78,10 @@ var width  = 640,
     frameReelRow   = document.querySelector("#area-frame-reel #reel-captured-imgs"),
     frameReelTable = document.querySelector("#area-frame-reel table"),
 
-    // Notification bar
-    notifyBar    = document.querySelector(".notification"),
-    notifyBarMsg = document.querySelector(".notification #msg"),
+    // Notifications
+    notifyBar     = document.querySelector(".notification"),
+    notifyBarMsg  = document.querySelector(".notification .msg"),
+    notifyBarType = document.querySelector(".notification .notify-type"),
 
     // Confirm messages
     confirmContainer    = document.querySelector("#confirm-container"),
@@ -793,6 +794,7 @@ function _notifyClose(msgType) {
     window.setTimeout(function() {
         notifyBar.classList.remove(msgType);
         notifyBarMsg.innerHTML = "";
+        notifyBarType.innerHTML = "";
     }, 1200 * timeout);
 }
 
@@ -805,6 +807,7 @@ function notifySuccess(msg) {
     "use strict";
     msg = msg || "";
 
+    notifyBarType.innerHTML = "Success";
     notifyBarMsg.innerHTML = msg;
     notifyBar.classList.add("success");
     notifyBar.classList.remove("hidden");
@@ -821,6 +824,7 @@ function notifyInfo(msg) {
     "use strict";
     msg = msg || "";
 
+    notifyBarType.innerHTML = "Info";
     notifyBarMsg.innerHTML = msg;
     notifyBar.classList.add("info");
     notifyBar.classList.remove("hidden");
@@ -837,6 +841,7 @@ function notifyError(msg) {
     "use strict";
     msg = msg || "";
 
+    notifyBarType.innerHTML = "Error";
     notifyBarMsg.innerHTML = msg;
     notifyBar.classList.add("error");
     notifyBar.classList.remove("hidden");


### PR DESCRIPTION
A small part of my larger work on #51. This lays the groundwork for my plans and makes the notifications look nicer.

### Success ###
![boats-success](https://cloud.githubusercontent.com/assets/3382464/11763691/892c5134-a0e2-11e5-8dc1-14fd27218e39.png)

### Info ###
![boats-info](https://cloud.githubusercontent.com/assets/3382464/11763692/8cf6f30a-a0e2-11e5-93db-d80b72fd9316.png)

### Error ###
![boats-error](https://cloud.githubusercontent.com/assets/3382464/11763696/96a4eec0-a0e2-11e5-9ffc-5eefe5453bf9.png)

The success and info colors still need adjusting to better match the UI colors.