### PR TITLE
Fix very tiny bug with border on capture window

### DIFF
--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -180,7 +180,8 @@ a {
 #captureWindow.hidden,
 #playbackWindow.hidden { display: none; }
 
-#captureWindow.active { border: 2px solid #ad0000; }
+#captureWindow { border: 2px solid transparent; }
+#captureWindow.active { border-color: #ad0000; }
 
 #preview {
   max-width: 100%;


### PR DESCRIPTION
When the `active` class is add/removed to/from `#captureWindow`, the element shrinks/grows by 2px. This PR fixes that. :)