### PR TITLE
Fix unset save directory on launch

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -72,10 +72,6 @@
                     <li>
                         <i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i>
                         <span class="sidebar-opt" id="btn-dir-change">Change directory</span>
-                    </li>
-                    <li>
-                        <i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i>
-                        <span class="sidebar-opt" id="btn-dir-default">Set as default directory</span>
                         <input id="chooseDirectory" style="display:none;" type="file" nwdirectory  />
                     </li>
                 </ul>


### PR DESCRIPTION
Fix #104, introduced in #102. If a save directory is not set on launch, immediately prompt to set it.

Also revise related messages to have consistent wording.