### PR TITLE
Fix #65 - onion skinning breaks if preview area is taller than it is wide and #117

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -92,7 +92,7 @@
 
     <div id="main-event">
         <!--Capture Window-->
-        <div id="captureWindow">
+        <div id="capture-window">
             <!--The actual onion skinning frame, injected through JS-->
             <img id="onion-skinning-frame">
             <!-- Video preview stream -->
@@ -100,7 +100,7 @@
         </div>
 
         <!--Playback Window-->
-        <div id="playbackWindow" class="hidden">
+        <div id="playback-window" class="hidden">
             <!--The actual playback window -->
             <img id="playback">
         </div>

--- a/app/animator.html
+++ b/app/animator.html
@@ -93,21 +93,16 @@
     <div id="main-event">
         <!--Capture Window-->
         <div id="captureWindow">
-            <div id="onionSkinningLayer">
-                <!--The actual onion skinning frame, injected through JS-->
-                <img id="onion-skinning-frame">
-            </div>
-
+            <!--The actual onion skinning frame, injected through JS-->
+            <img id="onion-skinning-frame">
             <!-- Video preview stream -->
             <video id="preview" autoplay>Video stream not available.</video>
         </div>
 
         <!--Playback Window-->
         <div id="playbackWindow" class="hidden">
-            <div id="playbackContainer">
-                <!--The actual playback window -->
-                <img id="playback">
-            </div>
+            <!--The actual playback window -->
+            <img id="playback">
         </div>
 
         <!--Playback controls-->

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -172,57 +172,54 @@ a {
 
 #captureWindow, #playbackWindow {
   height: calc(100vh - 200px);
-/*  height: 30em;*/
+  width: 100%;
   text-align: center;
   background-color: black;
+  position: relative;
+  border: 2px solid transparent;
 }
 
 #captureWindow.hidden,
 #playbackWindow.hidden { display: none; }
 
-#captureWindow { border: 2px solid transparent; }
 #captureWindow.active { border-color: #ad0000; }
 
 #preview {
-  max-width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
   padding: 0;
   margin: 0;
+  width: 100%;
   height: 100%;
-}
-
-.windowTitleContainer {
-  text-align: center;
-  display: inline-block;
+  object-fit: contain;
 }
 
 #playback {
-    height: calc((100vh - 200px));
-    width: calc(((100vh - 200px) / 3) * 4);
+  height: 100%;
+  width: 100%;
+  max-height: calc(100vh - 200px);
+  object-fit: contain;
 }
 
 /*========== ONION SKINNING ==============*/
 
-#onionSkinningLayer{
-  height: 0;
-  width: 100%;
-  overflow: visible;
-  padding: 0;
-  margin: 0;
-  z-index: 2;
-}
-
 #onion-skinning-frame {
-  position: relative;
+  height: 100%;
+  width: 100%;
   padding: 0;
   margin: 0;
   border: 0;
   opacity: 0.5;
+  position: absolute;
+  top: 0;
+  left: 0;
+  object-fit: contain;
+  z-index: 2;
   display: none;
-  width: calc(((100vh - 200px) / 3) * 4);
-  height: calc(100vh - 200px);
 }
-#onion-skinning-frame.visible { display: inline; }
 
+#onion-skinning-frame.visible { display: inline; }
 
 /* ========== CONTROLS ============== */
 

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -170,7 +170,7 @@ a {
 
 /* ========== VIDEO PREVIEW ============== */
 
-#captureWindow, #playbackWindow {
+#capture-window, #playback-window {
   height: calc(100vh - 200px);
   width: 100%;
   text-align: center;
@@ -179,10 +179,10 @@ a {
   border: 2px solid transparent;
 }
 
-#captureWindow.hidden,
-#playbackWindow.hidden { display: none; }
+#capture-window.hidden,
+#playback-window.hidden { display: none; }
 
-#captureWindow.active { border-color: #ad0000; }
+#capture-window.active { border-color: #ad0000; }
 
 #preview {
   position: absolute;

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -25,8 +25,8 @@ var width  = 640,
 
     // Mode switching
     btnLiveView    = document.querySelector("#btn-live-view"),
-    captureWindow  = document.querySelector("#captureWindow"),
-    playbackWindow = document.querySelector("#playbackWindow"),
+    captureWindow  = document.querySelector("#capture-window"),
+    playbackWindow = document.querySelector("#playback-window"),
     winMode        = "capture",
 
     // Capture


### PR DESCRIPTION
I've fixed the long term issue #65 and took the opportunity to remove some unnecessary "layer" elements. It took me a while to realise that the reason issue #65 didn't affect `#preview` was because WebKit assigns it the property `object-fit: contain;` by default - something I haven't come across before!

I'm also happy to say to say that the dodgy aspect ratio specific `calc()` widths are now gone.

Issue #117 is also fixed in this request with a transparent border being applied to the playback window.