### PR TITLE
Keyframes 1 fixes #116

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -124,9 +124,11 @@
                             </div>
                     </td>
                     <td id="playback-controls">
-                            <div id="btn-loop" class="mediaControls" title="Loop Playback"><i class="fa fa-refresh"></i></div>
-                            <div id="btn-stop" class="mediaControls" title="Stop Playback"><i class="fa fa-stop"></i></div>
-                            <div id="btn-play-pause" class="mediaControls" title="Playback Frames"><i class="fa fa-play"></i></div>
+                        <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
+                        <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
+                        <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
+                        <div id="btn-clear-keyframe" title="Clear Selection"><i class="fa fa-close"></i></div>
+                        <div id="btn-start-keyframe" title="Begin Selection"><i class="fa fa-arrow-right"></i></div>
                     </td>
                 </tr>
             </table>

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -270,13 +270,25 @@ a {
   color: #f3f76e;
 }
 
-#btn-play-pause, #btn-stop, #btn-loop {
+#playback-controls div {
   padding: 0 0.25em;
   float: right;
+  opacity: 1;
+  transition: opacity 0.2s linear;
+}
+
+#playback-controls div[disabled] {
+  cursor: default;
+  opacity: 0.45;
 }
 
 #btn-loop i.active, #btn-onion-skin-toggle i.active {
   color: #ad0000;
+}
+
+#btn-clear-keyframe { margin-right: 2em; }
+#btn-start-keyframe.active i, #btn-clear-keyframe.active i {
+  color: #0040FF;
 }
 
 /* ========== FRAME REEL ============== */
@@ -316,6 +328,9 @@ a {
 .frame-reel-img { cursor: pointer; }
 .frame-reel-img:hover { opacity: 0.8; }
 .frame-reel-img.selected { outline: 1px solid #d9d9d9; }
+
+/* Keyframes */
+.frame-reel-img.keyframe { border: 2px solid #0040FF; }
 
 /* Frame delete button */
 .btn-frame-delete {

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -274,12 +274,18 @@ a {
   padding: 0 0.25em;
   float: right;
   opacity: 1;
-  transition: opacity 0.2s linear;
+  transition: opacity 0.1s linear;
 }
 
 #playback-controls div[disabled] {
   cursor: default;
   opacity: 0.45;
+}
+
+#btn-play-pause {
+    box-sizing: content-box;
+    text-align: center;
+    width: 17px;
 }
 
 #btn-loop i.active, #btn-onion-skin-toggle i.active {

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -377,6 +377,7 @@ function _removeFrameReelSelection() {
 function _addFrameReelSelection(id) {
     "use strict";
     document.querySelector(`.frame-reel-img#img-${id}`).classList.add("selected");
+    curSelectedFrame = id;
 }
 
 /**
@@ -627,6 +628,10 @@ function videoPause() {
         btnPlayPause.children[0].classList.remove("fa-pause");
         btnPlayPause.children[0].classList.add("fa-play");
         console.info("Playback paused");
+
+        // Enable keyframe options
+        btnStartKeyframe.removeAttribute("disabled");
+        btnClearKeyframe.removeAttribute("disabled");
     }
 }
 
@@ -637,7 +642,12 @@ function videoStop() {
     "use strict";
     // Reset the player
     videoPause();
-    curPlayFrame = 0;
+    if (curStartKeyframe) {
+        // Reset playback
+        curPlayFrame = curStartKeyframe - 1;
+    } else {
+        curPlayFrame = 0;
+    }
     playback.setAttribute("src", capturedFramesRaw[curFrame - 1]);
 
     // Display newest frame number in status bar
@@ -670,10 +680,13 @@ function _videoPlay() {
             videoStop();
         } else {
             console.info("Playback looped");
+            if (curStartKeyframe) {
+                // Reset playback
+                curPlayFrame = curStartKeyframe - 1;
+            } else {
+                curPlayFrame = 0;
+            }
         }
-
-        // Reset playback
-        curPlayFrame = 0;
     }
 }
 
@@ -688,6 +701,10 @@ function previewCapturedFrames() {
     // Update the play/pause button
     btnPlayPause.children[0].classList.remove("fa-play");
     btnPlayPause.children[0].classList.add("fa-pause");
+
+    // Disable keyframe options
+    btnStartKeyframe.setAttribute("disabled", "");
+    btnClearKeyframe.setAttribute("disabled", "");
 
     // Begin playing the frames
     isPlaying = true;


### PR DESCRIPTION
I've had a few attempts at working out how to do this but believe this implementation works quite well.

In this pull request:
* 2 new buttons are added to the playback controls: "begin selection" and "clear selection" (`btn-start-keyframe` and `btn-clear-keyframe`). These are disabled with their opacity reduced when not required.
* 2 new functions added: `addKeyframe()` and `removeKeyframe()`. These have been implemented in such a way to allow to allow additional functionality to be added to the keyframe system in the future. These functions essentially set/clear a new variable `curStartKeyframe` and add/remove visual cues on the framereel.
* Changes to the playback code have been made to see if a `curStartKeyframe` has been set.

My more detailed functionality plan:
[Play Selection Plan.docx](https://github.com/BoatsAreRockable/animator/files/150963/Play.Selection.Plan.docx)

In #116 I suggested an `end selection` button as well. However, this created a number of complications and made this feature a much more confusing UX.

@le717 I'd welcome your feedback on this. Thanks! :)