### PR TITLE
Improve statusbar

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -165,9 +165,9 @@
 
     <div id="statusBar">
         <ul>
-            <li>Frame <span id="currentFrame">0</span> of <span id="num-of-frames">0</span></li>
-            <li id="currentFrameRate"><span></span> FPS</li>
-            <li class="no-pipe" id="currentMode"><span></span> mode</li>
+            <li>Frame <span id="current-frame">0</span> of <span id="num-of-frames">0</span></li>
+            <li id="current-frame-rate"><span></span> FPS</li>
+            <li class="no-pipe" id="current-mode"><span></span> mode</li>
             <li class="no-pipe" id="statusBar-credits"><a href="#" onclick="gui.Shell.openExternal('https://github.com/BoatsAreRockable/animator')">&copy; Charlie Lee 2016</a></li>
         </ul>
     </div>

--- a/app/animator.html
+++ b/app/animator.html
@@ -165,8 +165,7 @@
 
     <div id="statusBar">
         <ul>
-            <li id="currentFrame">Current frame: <span>0</span></li>
-            <li id="num-of-frames"><span>0 frames</span> captured</li>
+            <li>Frame <span id="currentFrame">0</span> of <span id="num-of-frames">0</span></li>
             <li id="currentFrameRate"><span></span> FPS</li>
             <li class="no-pipe" id="currentMode"><span></span> mode</li>
             <li class="no-pipe" id="statusBar-credits"><a href="#" onclick="gui.Shell.openExternal('https://github.com/BoatsAreRockable/animator')">&copy; Charlie Lee 2016</a></li>

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -54,10 +54,10 @@ var width  = 640,
     audioToggle  = document.querySelector("#audio-toggle"),
 
     // Status bar
-    statusBarCurMode   = document.querySelector("#currentMode span"),
-    statusBarCurFrame  = document.querySelector("#currentFrame"),
+    statusBarCurMode   = document.querySelector("#current-mode span"),
+    statusBarCurFrame  = document.querySelector("#current-frame"),
     statusBarFrameNum  = document.querySelector("#num-of-frames"),
-    statusBarFrameRate = document.querySelector("#currentFrameRate span"),
+    statusBarFrameRate = document.querySelector("#current-frame-rate span"),
 
     // Export frames
     frameExportDirectory  = null,

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -285,7 +285,7 @@ function startup() {
             playback.setAttribute("src", capturedFramesRaw[imageID - 1]);
             curPlayFrame = imageID - 1;
             curSelectedFrame = imageID;
-            statusBarCurFrame.innerHTML = imageID;
+            _updateStatusBarCurFrame(imageID);
         }
     });
 }
@@ -297,7 +297,7 @@ function switchMode(newMode) {
     "use strict";
     winMode = newMode;
     if (winMode === "capture") {
-        statusBarCurFrame.innerHTML = 0;
+        _updateStatusBarCurFrame(totalFrames + 1);
         playbackWindow.classList.add("hidden");
         captureWindow.classList.remove("hidden");
         captureWindow.classList.add("active");
@@ -337,6 +337,14 @@ function _addFrameReelSelection(id) {
     "use strict";
     document.querySelector(`.frame-reel-img#img-${id}`).classList.add("selected");
     curSelectedFrame = id;
+}
+
+/**
+ * Change the current frame number on the status bar.
+ * @param {Integer} id The value to change the frame number to.
+ */
+function _updateStatusBarCurFrame(id) {
+    "use strict";
     statusBarCurFrame.innerHTML = id;
 }
 
@@ -358,7 +366,7 @@ function updateFrameReel(action, id) {
     if (action === "capture") {
         // Remove any frame selection
         _removeFrameReelSelection();
-        statusBarCurFrame.innerHTML = 0;
+        _updateStatusBarCurFrame(totalFrames + 1);
 
         // Insert the new frame into the reel
         frameReelRow.insertAdjacentHTML("beforeend", `<td><div class="frame-reel-preview">
@@ -386,6 +394,7 @@ function updateFrameReel(action, id) {
         if (curSelectedFrame) {
             _removeFrameReelSelection();
             _addFrameReelSelection(id - 1);
+            _updateStatusBarCurFrame(id - 1);
         }
 
         // All the frames were deleted, display "No frames" message
@@ -547,7 +556,7 @@ function videoStop() {
     playback.setAttribute("src", capturedFramesRaw[totalFrames - 1]);
 
     // Display newest frame number in status bar
-    statusBarCurFrame.innerHTML = totalFrames;
+    _updateStatusBarCurFrame(totalFrames);
     console.info("Playback stopped");
 }
 
@@ -559,7 +568,7 @@ function _videoPlay() {
     // Display each frame
     _removeFrameReelSelection();
     playback.setAttribute("src", capturedFramesRaw[curPlayFrame]);
-    statusBarCurFrame.innerHTML = curPlayFrame + 1;
+    _updateStatusBarCurFrame(curPlayFrame + 1);
 
     // Display selection outline as each frame is played
     _addFrameReelSelection(curPlayFrame + 1);

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -55,8 +55,8 @@ var width  = 640,
 
     // Status bar
     statusBarCurMode   = document.querySelector("#currentMode span"),
-    statusBarCurFrame  = document.querySelector("#currentFrame span"),
-    statusBarFrameNum  = document.querySelector("#num-of-frames span"),
+    statusBarCurFrame  = document.querySelector("#currentFrame"),
+    statusBarFrameNum  = document.querySelector("#num-of-frames"),
     statusBarFrameRate = document.querySelector("#currentFrameRate span"),
 
     // Export frames
@@ -297,7 +297,7 @@ function switchMode(newMode) {
     "use strict";
     winMode = newMode;
     if (winMode === "capture") {
-        statusBarCurFrame.innerHTML = totalFrames;
+        statusBarCurFrame.innerHTML = 0;
         playbackWindow.classList.add("hidden");
         captureWindow.classList.remove("hidden");
         captureWindow.classList.add("active");
@@ -336,6 +336,8 @@ function _removeFrameReelSelection() {
 function _addFrameReelSelection(id) {
     "use strict";
     document.querySelector(`.frame-reel-img#img-${id}`).classList.add("selected");
+    curSelectedFrame = id;
+    statusBarCurFrame.innerHTML = id;
 }
 
 /**
@@ -350,13 +352,13 @@ function updateFrameReel(action, id) {
     "use strict";
     var onionSkinFrame = id - 1;
     // Display number of captured frames in status bar
-    statusBarCurFrame.innerHTML = totalFrames;
-    statusBarFrameNum.innerHTML = `${totalFrames} ${totalFrames === 1 ? "frame" : "frames"}`;
+    statusBarFrameNum.innerHTML = totalFrames;
 
     // Add the newly captured frame
     if (action === "capture") {
         // Remove any frame selection
         _removeFrameReelSelection();
+        statusBarCurFrame.innerHTML = 0;
 
         // Insert the new frame into the reel
         frameReelRow.insertAdjacentHTML("beforeend", `<td><div class="frame-reel-preview">
@@ -383,7 +385,7 @@ function updateFrameReel(action, id) {
         // Update frame preview selection
         if (curSelectedFrame) {
             _removeFrameReelSelection();
-            document.querySelector(`.frame-reel-img#img-${id - 1}`).classList.add("selected");
+            _addFrameReelSelection(id - 1);
         }
 
         // All the frames were deleted, display "No frames" message

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -31,7 +31,7 @@ var width  = 640,
 
     // Capture
     capturedFramesRaw  = [],
-    curFrame           = 0,
+    totalFrames        = 0,
     curSelectedFrame   = null,
     btnGridToggle      = document.querySelector("#btn-grid-toggle"),
     btnCaptureFrame    = document.querySelector("#btn-capture-frame"),
@@ -224,14 +224,14 @@ function startup() {
     // Play/pause the preview
     btnPlayPause.addEventListener("click", function() {
         // Make sure we have frames to play back
-        if (curFrame > 0) {
+        if (totalFrames > 0) {
             (isPlaying ? videoPause : previewCapturedFrames)();
         }
     });
 
     // Stop the preview
     btnStop.addEventListener("click", function() {
-        if (curFrame > 0) {
+        if (totalFrames > 0) {
             _removeFrameReelSelection();
             videoStop();
         }
@@ -297,7 +297,7 @@ function switchMode(newMode) {
     "use strict";
     winMode = newMode;
     if (winMode === "capture") {
-        statusBarCurFrame.innerHTML = curFrame;
+        statusBarCurFrame.innerHTML = totalFrames;
         playbackWindow.classList.add("hidden");
         captureWindow.classList.remove("hidden");
         captureWindow.classList.add("active");
@@ -350,8 +350,8 @@ function updateFrameReel(action, id) {
     "use strict";
     var onionSkinFrame = id - 1;
     // Display number of captured frames in status bar
-    statusBarCurFrame.innerHTML = curFrame;
-    statusBarFrameNum.innerHTML = `${curFrame} ${curFrame === 1 ? "frame" : "frames"}`;
+    statusBarCurFrame.innerHTML = totalFrames;
+    statusBarFrameNum.innerHTML = `${totalFrames} ${totalFrames === 1 ? "frame" : "frames"}`;
 
     // Add the newly captured frame
     if (action === "capture") {
@@ -365,14 +365,14 @@ function updateFrameReel(action, id) {
 
         // Remove the chosen frame
     } else if (action === "delete") {
-        if (id !== curFrame) {
+        if (id !== totalFrames) {
             onionSkinFrame = id - 2;
         }
         frameReelRow.removeChild(frameReelRow.children[id - 1]);
     }
 
     // We have frames, display them
-    if (curFrame > 0) {
+    if (totalFrames > 0) {
         frameReelMsg.classList.add("hidden");
         frameReelTable.classList.remove("hidden");
 
@@ -409,9 +409,9 @@ function deleteFrame(id) {
 
     exportedFramesList.splice(id - 1, 1);
     capturedFramesRaw.splice(id - 1, 1);
-    curFrame--;
+    totalFrames--;
     updateFrameReel("delete", id);
-    console.info(`There are now ${curFrame} captured frames`);
+    console.info(`There are now ${totalFrames} captured frames`);
 }
 
 /**
@@ -420,8 +420,8 @@ function deleteFrame(id) {
 function undoFrame() {
     "use strict";
     // Make sure there is a frame to delete
-    if (curFrame > 0) {
-      confirmSet(deleteFrame, curFrame, "Are you sure you want to delete the last frame captured?");
+    if (totalFrames > 0) {
+      confirmSet(deleteFrame, totalFrames, "Are you sure you want to delete the last frame captured?");
     } else {
       notifyError("There is no previous frame to undo!");
     }
@@ -447,8 +447,8 @@ function _toggleOnionSkin(ev) {
 
       // Display last captured frame
       onionSkinWindow.classList.add("visible");
-      if (curFrame > 0) {
-          onionSkinWindow.setAttribute("src", capturedFramesRaw[curFrame - 1]);
+      if (totalFrames > 0) {
+          onionSkinWindow.setAttribute("src", capturedFramesRaw[totalFrames - 1]);
       }
     }
 }
@@ -483,12 +483,12 @@ function takePicture() {
 
         // Store the image data and update the current frame
         capturedFramesRaw.push(data);
-        curFrame++;
-        console.info(`Captured frame: ${data.slice(100, 120)} There are now: ${curFrame} frames`);
+        totalFrames++;
+        console.info(`Captured frame: ${data.slice(100, 120)} There are now: ${totalFrames} frames`);
 
         // Save the frame to disk and update the frame reel
-        saveFrame(curFrame);
-        updateFrameReel("capture", curFrame);
+        saveFrame(totalFrames);
+        updateFrameReel("capture", totalFrames);
 
         // Scroll the frame reel to the end
         frameReelArea.scrollLeft = frameReelArea.scrollWidth;
@@ -542,10 +542,10 @@ function videoStop() {
     // Reset the player
     videoPause();
     curPlayFrame = 0;
-    playback.setAttribute("src", capturedFramesRaw[curFrame - 1]);
+    playback.setAttribute("src", capturedFramesRaw[totalFrames - 1]);
 
     // Display newest frame number in status bar
-    statusBarCurFrame.innerHTML = curFrame;
+    statusBarCurFrame.innerHTML = totalFrames;
     console.info("Playback stopped");
 }
 
@@ -568,7 +568,7 @@ function _videoPlay() {
     curPlayFrame++;
 
     // There are no more frames to preview
-    if (curPlayFrame >= curFrame) {
+    if (curPlayFrame >= totalFrames) {
          // We are not looping, stop the playback
         if (!isLooping) {
             videoStop();
@@ -607,7 +607,7 @@ function _frameReelScroll() {
     if (curPlayFrame === 0) {
         // Scroll to start when playback begins
         frameReelArea.scrollLeft = 0;
-    } else if (curPlayFrame + 1 !== curFrame) {
+    } else if (curPlayFrame + 1 !== totalFrames) {
         // Scroll so currently played frame is in view
         document.querySelector(`.frame-reel-img#img-${curPlayFrame + 2}`).scrollIntoView();
     } else {


### PR DESCRIPTION
I've made the status bar more compact and less "wordy":

Before:
![beforestatusbar](https://cloud.githubusercontent.com/assets/8095888/13437089/609e9a6a-dfda-11e5-870c-b6ee039d7d34.png)

After:
![statusafter](https://cloud.githubusercontent.com/assets/8095888/13436542/a641e48a-dfd7-11e5-9fa8-63b1efcd6878.png)

I've also changed a couple of things that were bugging me:
#### Renamed curFrame
Firstly I've renamed the variable `curFrame` to `totalFrames`. This was getting really confusing for me because `curFrame` didn't really reflect the variable's purpose (which is to provide the total number of frames captured). Also the variables `curSelectedFrame` and `curPlayFrame` were similarly named to `curFrame` but act quite differently to it since they change value relatively frequently while `curFrame` is more of a constant. In addition, the variable `statusBarCurFrame` was, despite its name, often not equal to var `curFrame`

#### Changed frame number when in capture mode
When in capture mode the frame number in the status bar is now 0. It was previously equal to the number of frames captured (or the old `curFrame`) which was confusing because the last frame captured would also display a frame number of `curFrame`.

There is a debate to be had that instead of 0 the frame number in capture mode should one more than the frame total (ie 19 in the example above) - which is how Dragonframe works. However, I personally find this quite confusing and in this proposed form the status bar would say `frame 19 of 18` which does sound rather clumsy...