### PR TITLE
Force use of npm v3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -61,6 +61,9 @@
     "js-flags": "",
     "app_name": "Boats Animator",
     "chromium-args": "",
+    "engines": {
+        "npm": "^3.7.3"
+    },
     "dependencies": {
         "mkdirp": "^0.5.1"
     },


### PR DESCRIPTION
This forces npm v3 be used when installing the app for development. Among other things, v3 should be used because it flat-packs the node_modules folder, meaning Windows users are less likely to hit the 255 file/folder character limit.

Note: after merging this, you'll need to update your node.js installation to >= 5.8.0 to have the specified npm version unless you update npm manually (`npm install npm -g`).