### PR TITLE
Removed dev tools and reload buttons

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -157,11 +157,6 @@
             <li>Frame <span id="current-frame">0</span> of <span id="num-of-frames">0</span></li>
             <li id="current-frame-rate"><span></span> FPS</li>
             <li class="no-pipe" id="current-mode"><span></span> mode</li>
-            <li id="statusBar-dev" class="no-pipe">
-                <!--Debugging Options-->
-                <button id="btn-open-dev-tools">Dev tools</button>
-                <button id="btn-dev-reload">Refresh</button>
-            </li>
         </ul>
     </div>
 

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -476,8 +476,6 @@ a {
   margin-left: 0.8em;
 }
 
-#statusBar-dev { float: right; }
-
 /* ========== SCROLL BARS ============== */
 
 ::-webkit-scrollbar              {

--- a/app/index.html
+++ b/app/index.html
@@ -41,11 +41,7 @@
 
     <div id="statusBar">
         <ul>
-            <li>Version <span id="app-version"></span></li>
-            <li>
-                <button id="btn-open-dev-tools">Dev tools</button>
-                <button id="btn-dev-reload">Refresh</button>
-            </li>
+            <li class="no-pipe">Version <span id="app-version"></span></li>
         </ul>
     </div>
 

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -32,10 +32,4 @@
     // Open the animator
     document.querySelector("#new-project").addEventListener("click", openAnimator);
 
-    /**
-     * Development Functions
-     */
-    document.querySelector("#btn-open-dev-tools").addEventListener("click", utils.showDev);
-
-    document.querySelector("#btn-dev-reload").addEventListener("click", utils.reloadPage);
 }());

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -314,7 +314,6 @@ function switchMode(newMode) {
         playbackWindow.classList.add("hidden");
         captureWindow.classList.remove("hidden");
         captureWindow.classList.add("active");
-        captureWindow.classList.add("active");
         btnLiveView.classList.add("selected");
 
     } else if (winMode === "playback") {

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -301,10 +301,6 @@ function startup() {
             _updateStatusBarCurFrame(imageID);
         }
     });
-  
-  // Developer buttons
-  document.querySelector("#btn-open-dev-tools").addEventListener("click", utils.showDev);
-  document.querySelector("#btn-dev-reload").addEventListener("click", utils.reloadPage);
 }
 
 /**
@@ -317,6 +313,7 @@ function switchMode(newMode) {
         _updateStatusBarCurFrame(totalFrames + 1);
         playbackWindow.classList.add("hidden");
         captureWindow.classList.remove("hidden");
+        captureWindow.classList.add("active");
         captureWindow.classList.add("active");
         btnLiveView.classList.add("selected");
 
@@ -913,8 +910,7 @@ function loadMenu() {
     var fileMenu    = new nw.Menu(),
         editMenu    = new nw.Menu(),
         captureMenu = new nw.Menu(),
-        helpMenu    = new nw.Menu(),
-        debugMenu   = new nw.Menu();
+        helpMenu    = new nw.Menu();
 
     // File menu items
     fileMenu.append(new nw.MenuItem({
@@ -971,12 +967,6 @@ function loadMenu() {
       click: openAbout
     }));
 
-    // Debug menu items
-    debugMenu.append(new nw.MenuItem({
-      label: "Load developer tools",
-      click: utils.showDev,
-    }));
-
     // Append sub-menus to main menu
     menuBar.append(
         new nw.MenuItem({
@@ -1003,13 +993,6 @@ function loadMenu() {
         new nw.MenuItem({
             label: "Help",
             submenu: helpMenu
-        })
-    );
-
-    menuBar.append(
-        new nw.MenuItem({
-            label: "Debug",
-            submenu: debugMenu
         })
     );
 

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -13,6 +13,6 @@ const utils = (function() {
     }
 
     return {
-        openURL   : openURL
+        openURL: openURL
     };
 }());

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -12,27 +12,7 @@ const utils = (function() {
         nw.Shell.openExternal(url);
     }
 
-    /**
-     * Open the browser developer tools.
-     */
-    function showDev() {
-        // TODO Because nw.js 0.13 only has the dev tools in the
-        // SDK build and not release build, we will need to make sure
-        // this method exists when before running it when we upgrade
-        win.showDevTools();
-    }
-
-    /**
-     * Reload the current page.
-     */
-    function reloadPage() {
-        // nw-TODO reloadDev() is not yet supported
-        win.reload();
-    }
-
     return {
-        openURL   : openURL,
-        showDev   : showDev,
-        reloadPage: reloadPage
+        openURL   : openURL
     };
 }());


### PR DESCRIPTION
This removes the dev-tools and refresh buttons that were in various locations. Nw.js 0.13's SDK builds provide access to dev tools via F12 and a "reload app" option accessed via right click.
